### PR TITLE
template: Ruby indentation is 2, not 4, spaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ var templateString = `
 {{range .}}
   go_resource "{{.ImportPath}}" do
     url "{{.ClonePath}}",
-        :revision => "{{.Revision}}"{{if .VCS}}, :using => :{{.VCS}}{{end}}
+      :revision => "{{.Revision}}"{{if .VCS}}, :using => :{{.VCS}}{{end}}
   end
 {{end}}
 `


### PR DESCRIPTION
When testing this out, I noticed that the `:revision` symbol is indented a bit too far.
