### PR TITLE
fix install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Flags:
 ### Install
 
 ```
-go get github.com/samertm/homebrew-go-resources
+go install github.com/samertm/homebrew-go-resources@latest
 ```


### PR DESCRIPTION
The old instructions error:

```
⇒ go get github.com/samertm/homebrew-go-resources
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

So I updated them to use `go install` as suggested.